### PR TITLE
Add `assert { type: "json" }` to json import

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -2,7 +2,7 @@ import { rm, mkdir } from 'fs/promises';
 import { rollup } from 'rollup';
 import typescript from '@rollup/plugin-typescript';
 import { terser } from 'rollup-plugin-terser';
-import pkg from '../package.json';
+import pkg from '../package.json' assert { type: "json" };
 
 const banner = `
 /**


### PR DESCRIPTION
I ran into the error `ERR_IMPORT_ASSERTION_TYPE_MISSING` when running `npm run build` (node version v18.17.1). Adding `assert { type: "json" }` seems to fix it.

Ref: https://stackoverflow.com/questions/70106880/err-import-assertion-type-missing-for-import-of-json-file